### PR TITLE
Migrate from Log4j to SLF4J API for logging

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     compile 'commons-codec:commons-codec:1.11'
     compile 'com.google.code.gson:gson:2.8.2'
     compile 'org.glassfish.tyrus.bundles:tyrus-standalone-client:1.13.1'
-    compile 'org.apache.logging.log4j:log4j-api:2.10.0'
+    compile 'org.slf4j:slf4j-api:1.7.25'
     compile 'org.jetbrains:annotations:16.0.1'
 
     testCompile 'junit:junit:4.12'

--- a/client/src/main/java/com/assemblypayments/spi/Connection.java
+++ b/client/src/main/java/com/assemblypayments/spi/Connection.java
@@ -1,9 +1,9 @@
 package com.assemblypayments.spi;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.glassfish.tyrus.client.ClientManager;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.websocket.*;
 import javax.websocket.CloseReason.CloseCodes;
@@ -17,7 +17,7 @@ import java.util.concurrent.TimeUnit;
 
 class Connection {
 
-    private static final Logger LOG = LogManager.getLogger("spi");
+    private static final Logger LOG = LoggerFactory.getLogger("spi");
 
     private static final long CONNECTION_TIMEOUT = TimeUnit.SECONDS.toMillis(8);
     private EventHandler eventHandler;

--- a/client/src/main/java/com/assemblypayments/spi/Spi.java
+++ b/client/src/main/java/com/assemblypayments/spi/Spi.java
@@ -3,10 +3,10 @@ package com.assemblypayments.spi;
 import com.assemblypayments.spi.model.*;
 import com.assemblypayments.spi.util.*;
 import org.apache.commons.lang.StringUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.websocket.DeploymentException;
 import java.io.IOException;
@@ -26,7 +26,7 @@ public class Spi {
 
     //region Private state
 
-    private static final Logger LOG = LogManager.getLogger("spi");
+    private static final Logger LOG = LoggerFactory.getLogger("spi");
 
     static final String PROTOCOL_VERSION = "2.3.0";
 

--- a/client/src/main/java/com/assemblypayments/spi/SpiPayAtTable.java
+++ b/client/src/main/java/com/assemblypayments/spi/SpiPayAtTable.java
@@ -2,16 +2,16 @@ package com.assemblypayments.spi;
 
 import com.assemblypayments.spi.model.*;
 import com.assemblypayments.spi.util.RequestIdHelper;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class SpiPayAtTable {
 
-    private static final Logger LOG = LogManager.getLogger("spipat");
+    private static final Logger LOG = LoggerFactory.getLogger("spipat");
 
     private final Spi spi;
 

--- a/client/src/main/java/com/assemblypayments/spi/SpiPreauth.java
+++ b/client/src/main/java/com/assemblypayments/spi/SpiPreauth.java
@@ -2,13 +2,13 @@ package com.assemblypayments.spi;
 
 import com.assemblypayments.spi.model.*;
 import com.assemblypayments.spi.util.Events;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SpiPreauth {
 
-    private static final Logger LOG = LogManager.getLogger("spipreauth");
+    private static final Logger LOG = LoggerFactory.getLogger("spipreauth");
 
     private final Spi spi;
     private final Object txLock;

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -16,5 +16,5 @@ run {
 
 dependencies {
     compile project(':client')
-    compile 'org.apache.logging.log4j:log4j-core:2.10.0'
+    compile 'org.apache.logging.log4j:log4j-slf4j-impl:2.10.0'
 }


### PR DESCRIPTION
- Swap Log4j for SLF4J as the logging API to simplify Android support
- Configure sample to continue using Log4j as underlying SLF4J implementation (via `log4j-slf4j-impl`)