### PR TITLE
SCLJ-19 Resilience against out of order GLT responses

### DIFF
--- a/client/src/main/java/com/assemblypayments/spi/Spi.java
+++ b/client/src/main/java/com/assemblypayments/spi/Spi.java
@@ -775,6 +775,8 @@ public class Spi {
                     message.getId(), TransactionType.GET_LAST_TRANSACTION, 0, message,
                     "Waiting for EFTPOS connection to make a Get-Last-Transaction request"));
 
+            getCurrentTxFlowState().callingGlt(message.getId());
+
             if (send(message)) {
                 getCurrentTxFlowState().sent("Asked EFTPOS to Get Last Transaction.");
             }
@@ -1102,7 +1104,17 @@ public class Spi {
         synchronized (txLock) {
             TransactionFlowState txState = getCurrentTxFlowState();
             if (getCurrentFlow() != SpiFlow.TRANSACTION || txState.isFinished()) {
-                // We were not in the middle of a transaction, who cares?
+                LOG.info("Received glt response but we were not in the middle of a tx. ignoring.");
+                return;
+            }
+
+            if (!getCurrentTxFlowState().isAwaitingGltResponse()) {
+                LOG.info("received a glt response but we had not asked for one within this transaction. Perhaps leftover from previous one. ignoring.");
+                return;
+            }
+
+            if (!getCurrentTxFlowState().getLastGltRequestId().equals(m.getId())) {
+                LOG.info("received a glt response but the message id does not match the glt request that we sent. strange. ignoring.");
                 return;
             }
 
@@ -1186,7 +1198,6 @@ public class Spi {
                             } else if (txState.isRequestSent() && System.currentTimeMillis() > txState.getLastStateRequestTime() + CHECK_ON_TX_FREQUENCY) {
                                 // TH-1T, TH-4T - It's been a while since we received an update, let's call a GLT
                                 LOG.info("Checking on our transaction. Last we asked was at " + txState.getLastStateRequestTime() + "...");
-                                txState.callingGlt();
                                 callGetLastTransaction();
                             }
                         }
@@ -1388,7 +1399,6 @@ public class Spi {
                 if (getCurrentTxFlowState().isRequestSent()) {
                     // TH-3A - We've just reconnected and were in the middle of Tx.
                     // Let's get the last transaction to check what we might have missed out on.
-                    getCurrentTxFlowState().callingGlt();
                     callGetLastTransaction();
                 } else {
                     // TH-3AR - We had not even sent the request yet. Let's do that now
@@ -1455,8 +1465,9 @@ public class Spi {
      * Ask the PIN pad to tell us what the most recent transaction was.
      */
     private void callGetLastTransaction() {
-        final GetLastTransactionRequest gltRequest = new GetLastTransactionRequest();
-        send(gltRequest.toMessage());
+        final Message gltMessage = new GetLastTransactionRequest().toMessage();
+        getCurrentTxFlowState().callingGlt(gltMessage.getId());
+        send(gltMessage);
     }
 
     /**

--- a/client/src/main/java/com/assemblypayments/spi/model/TransactionFlowState.java
+++ b/client/src/main/java/com/assemblypayments/spi/model/TransactionFlowState.java
@@ -12,6 +12,7 @@ public class TransactionFlowState {
     private boolean requestSent;
     private long requestTime;
     private long lastStateRequestTime;
+    private String lastGltRequestId;
     private boolean attemptingToCancel;
     private boolean awaitingSignatureCheck;
     private boolean awaitingPhoneForAuth;
@@ -55,9 +56,10 @@ public class TransactionFlowState {
         this.displayMessage = msg;
     }
 
-    public void callingGlt() {
+    public void callingGlt(String gltRequestId) {
         this.awaitingGltResponse = true;
         this.lastStateRequestTime = System.currentTimeMillis();
+        this.lastGltRequestId = gltRequestId;
     }
 
     public void gotGltResponse() {
@@ -234,6 +236,21 @@ public class TransactionFlowState {
     }
 
     /**
+     * @return The id of the last glt request message that was sent. used to match with the response.
+     */
+    public String getLastGltRequestId() {
+        return lastGltRequestId;
+    }
+
+    /**
+     * @param lastGltRequestId The id of the last glt request message that was sent. used to match with the response.
+     */
+    public void setLastGltRequestId(String lastGltRequestId) {
+        this.lastGltRequestId = lastGltRequestId;
+    }
+
+
+    /**
      * @return Whether we're currently attempting to Cancel the transaction.
      */
     public boolean isAttemptingToCancel() {
@@ -400,7 +417,7 @@ public class TransactionFlowState {
     }
 
     /**
-     *The pos ref id  when Get Last Transaction response. The pos ref id  when Get Last Transaction response.
+     * The pos ref id  when Get Last Transaction response. The pos ref id  when Get Last Transaction response.
      */
     public String getGltResponsePosRefId() {
         return gltResponsePosRefId;


### PR DESCRIPTION
In some circumstances, the GLT message id received from the terminal does not match with GLT request that was sent, we need to ignore it and continue.